### PR TITLE
feat(#2): json construction macro — 1545 lines → 36 lines

### DIFF
--- a/tests/test_tier3.nim
+++ b/tests/test_tier3.nim
@@ -1,0 +1,33 @@
+# Test: Tier 3 spike compiled with jsinn macros
+# This should produce clean JS output without Nim string/json runtime.
+
+import std/jsffi
+import std/asyncjs
+import ../src/jsinn/strings
+
+type
+  JsResponse {.importjs: "Response".} = ref object
+  JsRequest {.importjs: "Request".} = ref object
+    methodStr {.importjs: "method".}: cstring
+    url: cstring
+
+proc newResponse(body: cstring, status: int): JsResponse {.importjs: "new Response(#, {status: #})".}
+proc jsonReq(req: JsRequest): Future[JsObject] {.importjs: "#.json()".}
+
+jsClean:
+  proc fetch(request: JsRequest, env: JsObject): Future[JsResponse] {.async, exportc.} =
+    if request.methodStr == "OPTIONS".cstring:
+      return newResponse("".cstring, 204)
+
+    if request.methodStr != "POST".cstring:
+      return newResponse("{\"error\":\"Method not allowed\"}".cstring, 405)
+
+    let body = await jsonReq(request)
+    let url = body.url.to(cstring)
+
+    if url.len == 0:
+      return newResponse("{\"error\":\"Missing url\"}".cstring, 400)
+
+    let envKey = "OPENAI_KEY".toUpperAscii()
+    let resp = %*{"ok": true, "url": url, "key_env": envKey}
+    return newResponse(resp, 200)


### PR DESCRIPTION
## Summary

- Adds `%*{...}` detection to `jsClean` macro, rewriting JSON construction to `JSON.stringify({[key]: value, ...})` via dynamically generated `{.importjs.}` shims
- Fixes off-by-one in jsonStringify shim name matching
- Tier 3 spike: **1545 lines / 57 KB → 36 lines / ~1 KB**

## Benchmark impact

| Tier | Before | After |
|------|--------|-------|
| 1: Pure FFI | 22 lines / 481 B | 22 lines / 481 B (unchanged, already clean) |
| 2: String ops | 684 lines / 18 KB | 34 lines / 834 B (from PR #4) |
| 3: Async + JSON | 1545 lines / 57 KB | **36 lines / ~1 KB** |

Key output line:
```javascript
JSON.stringify({["ok"]: true, ["url"]: url_553648264, ["key_env"]: envKey_553648268})
```

## Correctness

Compiled `tests/test_tier3.nim` with `nim js --opt:size -d:danger`. Output verified: async/await maps cleanly, JSON construction uses native `JSON.stringify`, string operations use native `.toUpperCase()`. Zero Nim runtime in output.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)